### PR TITLE
only uri_escape parts of the path

### DIFF
--- a/lib/WebService/AWS/Auth/V4.pm6
+++ b/lib/WebService/AWS/Auth/V4.pm6
@@ -211,7 +211,7 @@ class WebService::AWS::Auth::V4 {
     method canonical_uri() returns Str:D is export {
         my Str $path = $!uri.path;
         return '/' if $path.chars == 0 || $path eq '/';
-        uri_escape($path);
+        $path.split("/").map({uri_escape($_)}).join("/");
     }
 
     method canonical_query() returns Str:D is export {

--- a/t/basic.t
+++ b/t/basic.t
@@ -75,7 +75,7 @@ lives-ok {
 
 lives-ok {
     my $v4 = WebService::AWS::Auth::V4.new(method => $get, body => '', uri => 'https://iam.amazonaws.com/home/documents+and+settings?a/z=b&C=d', headers => @headers, region => $region, service => $service, secret => $secret, access_key => $access_key);
-    is $v4.canonical_uri(), '%2Fhome%2Fdocuments%2Band%2Bsettings', 'canonicalizes nonempty URI path';
+    is $v4.canonical_uri(), '/home/documents%2Band%2Bsettings', 'canonicalizes nonempty URI path';
     is $v4.canonical_query(), 'C=d&a%2Fz=b', 'canonicalizes nonempty query';
 }, 'correctly canonicalized nonempty query';
 


### PR DESCRIPTION
Hi,

Attached is a change that only uri_encodes parts of the path when computing the
canonical request, per the docs here:
    http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
(and from my testing)

thanks
Brian
