### PR TITLE
Fixes for changes in URI module

### DIFF
--- a/lib/WebService/AWS/Auth/V4.pm6
+++ b/lib/WebService/AWS/Auth/V4.pm6
@@ -230,9 +230,9 @@ class WebService::AWS::Auth::V4 {
     # STEP 1 CANONICAL REQUEST
     
     method canonical-uri(--> Str:D) is export {
-        my Str $path = $!uri.path;
+        my $path = $!uri.path.Str;
         return '/' if $path.chars == 0 || $path eq '/';
-        $path.split("/").map({uri-escape($_)}).join("/");
+        $path.split("/").map({uri-escape(uri-unescape($_))}).join("/");
     }
 
     # Old name for canonical-uri; support old api.
@@ -241,7 +241,7 @@ class WebService::AWS::Auth::V4 {
     }
     
     method canonical-query(--> Str:D) is export {
-        my Str $query = $!uri.query;
+        my Str $query = $!uri.query.Str;
         return '' if $query.chars == 0;
         my Str @pairs = $query.split('&');
         my Str @escaped_pairs = ();

--- a/t/basic.t
+++ b/t/basic.t
@@ -75,7 +75,7 @@ lives-ok {
 
 lives-ok {
     my $v4 = WebService::AWS::Auth::V4.new(method => $get, body => '', uri => 'https://iam.amazonaws.com/home/documents+and+settings?a/z=b&C=d', headers => @headers, region => $region, service => $service, secret => $secret, access_key => $access_key);
-    is $v4.canonical-uri(), '/home/documents%2Band%2Bsettings', 'canonicalizes nonempty URI path';
+    is $v4.canonical-uri(), '/home/documents%20and%20settings', 'canonicalizes nonempty URI path';
     is $v4.canonical-query(), 'C=d&a%2Fz=b', 'canonicalizes nonempty query';
 }, 'correctly canonicalized nonempty query';
 


### PR DESCRIPTION
The explicit stringification of path and query is to work with the https://github.com/perl6-community-modules/uri/pull/44 but is a harmless no-op with the current HEAD of URI.
The unecape/escape locution is to prevent double escaping is to deal
with a similar round trip that was added to deal with unicode in paths.
The change in escaping in the test is because the '+' is unescaped to a
space now (this change in URI literally happened after your last
commit.)